### PR TITLE
feat: 支持 Ubuntu 系统并新增 OS 选择下拉

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,7 +107,7 @@
         <select id="osType" onchange="updateOsTip()">
             <option value="auto">自动检测 (推荐)</option>
             <option value="centos">CentOS 7 x64</option>
-            <option value="ubuntu">Ubuntu 20.04 / 22.04 x64</option>
+            <option value="ubuntu">Ubuntu 20.04 / 22.04 / 24.04 x64</option>
         </select>
     </label>
     <p id="osTip">已支持 <span class="highlight">CentOS 7</span> 与 <span class="highlight">Ubuntu</span>，安装脚本会自动识别系统并选用对应包管理器 (yum/apt)。不要使用 <span class="highlight">CentOS 8</span>。</p>
@@ -228,7 +228,7 @@ scp v2ray-docker.zip root@__TargetIP__:/root</textarea>
     const tips = {
       auto: '已支持 <span class="highlight">CentOS 7</span> 与 <span class="highlight">Ubuntu</span>，安装脚本会自动识别系统并选用对应包管理器 (yum/apt)。不要使用 <span class="highlight">CentOS 8</span>。',
       centos: '推荐 <span class="highlight">CentOS 7 x64</span>，脚本使用 <span class="highlight">yum</span> 安装依赖。不要使用 <span class="highlight">CentOS 8</span>。',
-      ubuntu: '推荐 <span class="highlight">Ubuntu 20.04 / 22.04 x64</span>，脚本使用 <span class="highlight">apt</span> 安装依赖（执行前会自动 apt-get update）。'
+      ubuntu: '推荐 <span class="highlight">Ubuntu 20.04 / 22.04 / 24.04 x64</span>，脚本使用 <span class="highlight">apt</span> 安装依赖（执行前会自动 apt-get update）。'
     };
     tip.innerHTML = tips[sel.value] || tips.auto;
   }

--- a/index.html
+++ b/index.html
@@ -100,7 +100,17 @@
 
     <h2>2️⃣ 部署</h2>
 
-    服务器系统推荐: <span class="highlight">CentOS 7 x64</span>, 不要使用<span class="highlight">CentOS 8</span>
+    <label for="osType">
+        <div class="required">
+            服务器系统
+        </div>
+        <select id="osType" onchange="updateOsTip()">
+            <option value="auto">自动检测 (推荐)</option>
+            <option value="centos">CentOS 7 x64</option>
+            <option value="ubuntu">Ubuntu 20.04 / 22.04 x64</option>
+        </select>
+    </label>
+    <p id="osTip">已支持 <span class="highlight">CentOS 7</span> 与 <span class="highlight">Ubuntu</span>，安装脚本会自动识别系统并选用对应包管理器 (yum/apt)。不要使用 <span class="highlight">CentOS 8</span>。</p>
 
     <ol>
         <li>
@@ -193,6 +203,7 @@ scp v2ray-docker.zip root@__TargetIP__:/root</textarea>
 <script>
   regenerateClientId();
   generateClientConfig();
+  updateOsTip();
   const clipboard = new ClipboardJS('.copy-btn');
 
   clipboard.on('success', function (e) {
@@ -208,6 +219,18 @@ scp v2ray-docker.zip root@__TargetIP__:/root</textarea>
 
   function regenerateClientId() {
     document.getElementById('clientId').value = uuid.v4();
+  }
+
+  function updateOsTip() {
+    const sel = document.getElementById('osType');
+    const tip = document.getElementById('osTip');
+    if (!sel || !tip) return;
+    const tips = {
+      auto: '已支持 <span class="highlight">CentOS 7</span> 与 <span class="highlight">Ubuntu</span>，安装脚本会自动识别系统并选用对应包管理器 (yum/apt)。不要使用 <span class="highlight">CentOS 8</span>。',
+      centos: '推荐 <span class="highlight">CentOS 7 x64</span>，脚本使用 <span class="highlight">yum</span> 安装依赖。不要使用 <span class="highlight">CentOS 8</span>。',
+      ubuntu: '推荐 <span class="highlight">Ubuntu 20.04 / 22.04 x64</span>，脚本使用 <span class="highlight">apt</span> 安装依赖（执行前会自动 apt-get update）。'
+    };
+    tip.innerHTML = tips[sel.value] || tips.auto;
   }
 
   function saveAs(blob, filename) {

--- a/v2ray_config/init-v2ray.sh
+++ b/v2ray_config/init-v2ray.sh
@@ -1,11 +1,70 @@
 #!/bin/bash
+set -e
 
-if ! [ -x "$(command -v wget)" ]; then
-  yum -y install wget
+# detect OS via /etc/os-release
+OS_ID="unknown"
+if [ -r /etc/os-release ]; then
+  . /etc/os-release
+  OS_ID="${ID:-unknown}"
+  OS_LIKE="${ID_LIKE:-}"
+fi
+
+case "${OS_ID}:${OS_LIKE}" in
+  centos:*|rhel:*|fedora:*|rocky:*|almalinux:*|*:*rhel*|*:*fedora*)
+    PKG_FAMILY="rhel"
+    ;;
+  ubuntu:*|debian:*|*:*debian*)
+    PKG_FAMILY="debian"
+    ;;
+  *)
+    if command -v apt-get >/dev/null 2>&1; then
+      PKG_FAMILY="debian"
+    elif command -v yum >/dev/null 2>&1; then
+      PKG_FAMILY="rhel"
+    elif command -v dnf >/dev/null 2>&1; then
+      PKG_FAMILY="rhel"
+    else
+      echo "Unsupported OS: ${OS_ID}. Please install wget/curl/docker/docker-compose manually."
+      PKG_FAMILY="unknown"
+    fi
+    ;;
+esac
+
+echo "Detected OS: ${OS_ID} (package family: ${PKG_FAMILY})"
+
+pkg_install() {
+  case "$PKG_FAMILY" in
+    rhel)
+      if command -v dnf >/dev/null 2>&1; then
+        sudo dnf -y install "$@"
+      else
+        sudo yum -y install "$@"
+      fi
+      ;;
+    debian)
+      sudo apt-get update -y
+      sudo DEBIAN_FRONTEND=noninteractive apt-get install -y "$@"
+      ;;
+    *)
+      echo "Skip install: unsupported package family for $*"
+      ;;
+  esac
+}
+
+# install wget if missing
+if ! command -v wget >/dev/null 2>&1; then
+  echo "Installing wget..."
+  pkg_install wget
+fi
+
+# install curl if missing (needed to fetch docker-compose binary)
+if ! command -v curl >/dev/null 2>&1; then
+  echo "Installing curl..."
+  pkg_install curl
 fi
 
 # install docker if not exists
-if ! [ -x "$(command -v docker)" ]; then
+if ! command -v docker >/dev/null 2>&1; then
   echo "Installing docker..."
   wget -qO- https://get.docker.com/ | sh
   sudo systemctl enable docker
@@ -15,17 +74,19 @@ else
 fi
 
 # install docker-compose if not exists
-if ! [ -x "$(command -v docker-compose)" ]; then
+if ! command -v docker-compose >/dev/null 2>&1; then
   echo "Installing docker-compose..."
   sudo curl -L "https://github.com/docker/compose/releases/download/1.24.1/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
   sudo chmod +x /usr/local/bin/docker-compose
-  sudo ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
+  if [ ! -e /usr/bin/docker-compose ]; then
+    sudo ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
+  fi
 else
   echo "Docker-compose is already installed"
 fi
 
 # timezone
-timedatectl set-timezone Asia/Shanghai
+sudo timedatectl set-timezone Asia/Shanghai || true
 
 docker-compose up -d
 


### PR DESCRIPTION
## 背景

issue AOL-27: 之前只支持 CentOS 7，现在扩展支持 Ubuntu。`yum` 仅在 CentOS/RHEL 系可用，Ubuntu 使用 `apt`，需要做适配。

## 变更内容

- `v2ray_config/init-v2ray.sh`：
  - 通过 `/etc/os-release` 自动识别 OS。
  - RHEL 系（centos/rhel/fedora/rocky/almalinux）走 `yum`/`dnf`；Debian 系（ubuntu/debian）走 `apt-get`（前置 `apt-get update`，`DEBIAN_FRONTEND=noninteractive` 避免交互卡住）。
  - 兼容 `wget`/`curl` 缺失场景；docker、docker-compose、timezone 设置逻辑保持不变。
  - 软链接 `/usr/bin/docker-compose` 已存在时不再重复创建。
- `index.html`：
  - 在 "2️⃣ 部署" 区块新增系统下拉：自动检测 (推荐) / CentOS 7 / Ubuntu。
  - 切换下拉时动态更新部署提示文案，告知不同系统对应的包管理器。

## 测试计划

- [ ] 在 CentOS 7 上执行 `./init-v2ray.sh`，确认通过 yum 安装 wget/curl 并完成 docker 部署
- [ ] 在 Ubuntu 20.04 / 22.04 上执行 `./init-v2ray.sh`，确认通过 apt 安装 wget/curl 并完成 docker 部署
- [ ] 在 GitHub Pages 上访问页面，验证 OS 下拉切换提示文案