### PR TITLE
fix: add compose file version

### DIFF
--- a/v2ray_config/docker-compose.yml
+++ b/v2ray_config/docker-compose.yml
@@ -1,3 +1,5 @@
+version: "3"
+
 services:
   v2ray:
     image: v2ray/official


### PR DESCRIPTION
## Summary
- Add an explicit Compose file version to the generated docker-compose.yml template for Docker Compose v1 compatibility

## Verification
- docker compose -f v2ray_config/docker-compose.yml config